### PR TITLE
Ignore overlays/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin
 .classpath
 /target
 .springBeans
+overlays/


### PR DESCRIPTION
IntelliJ IDEA unpacks overlays to a overlays/ folder; they should never be committed.